### PR TITLE
Fixes a bug with how extensions are handled

### DIFF
--- a/vcs_server/VcsPlot.py
+++ b/vcs_server/VcsPlot.py
@@ -55,6 +55,11 @@ class VcsPlot(object):
                     setattr(my_gm, k, gm[k])
                 except:
                     print "Could not set attribute %s on graphics method of type %s" % (k, t)
+        if "ext_1" in gm:
+            my_gm.ext_1 = gm["ext_1"]
+        if "ext_2" in gm:
+            my_gm.ext_2 = gm["ext_2"]
+
         self._plot.graphics_method = my_gm
 
     def setTemplate(self, template):


### PR DESCRIPTION
This fixes an inconvenience in the VCS api when working with javascript. VCS graphics methods have the `ext_1` and `ext_2` attributes, which insert `-1e20` at the beginning or `1e20` at the end of the `levels` array, respectively. Since there's no built-in storage for those attributes, this causes some headaches. JavaScript expects ext_1 and ext_2 to just be normal booleans; it's easiest if the user doesn't need to futz around with the levels array when turning on / disabling extensions. So, this just makes sure that ext_1 and ext_2 are set based on the boolean values provided, once the levels have (possibly) been set. If `-1e20` and `1e20` are already there, it'll behave exactly the same as before. If they aren't, it'll automatically repair the levels array to be like VCS expects. This might cause an issue if the user sticks 1e20 or -1e20 as levels, but I'm willing to punt on solving that specific (weird) use case.