### PR TITLE
Remove provenance code dependency

### DIFF
--- a/vcs_server/VcsPlot.py
+++ b/vcs_server/VcsPlot.py
@@ -67,18 +67,21 @@ class VcsPlot(object):
         self._plot.graphics_method = my_gm
 
     def setTemplate(self, template):
-        my_tmpl = vcs.createtemplate()
-        for attr in template:
-            if attr == "name":
-                continue
-            if attr == "p_name":
-                continue
-            for key in template[attr]:
-                if key == "member":
+        if isinstance(template, dict):
+            my_tmpl = vcs.createtemplate()
+            for attr in template:
+                if attr == "name":
                     continue
-                tmpl_attr = getattr(my_tmpl, attr)
-                new_val = template[attr][key]
-                setattr(tmpl_attr, key, new_val)
+                if attr == "p_name":
+                    continue
+                for key in template[attr]:
+                    if key == "member":
+                        continue
+                    tmpl_attr = getattr(my_tmpl, attr)
+                    new_val = template[attr][key]
+                    setattr(tmpl_attr, key, new_val)
+        else:
+            my_tmpl = vcs.gettemplate(str(template))
         self._plot.template = my_tmpl
 
     def loadVariable(self, var, opts={}):

--- a/vcs_server/Visualizer.py
+++ b/vcs_server/Visualizer.py
@@ -39,7 +39,7 @@ class Visualizer(tornado.websocket.WebSocketHandler):
         vis.setTemplate(template)
         all_vars = []
         for obj in variable:
-            all_vars.append(cdms2.open(obj))
+            all_vars.append(cdms2.open(obj["uri"])(obj["variable"]))
         vis.loadVariable(all_vars)
 
     def mouseDown(self, x, y):


### PR DESCRIPTION
Due to time constraints of me leaving, the "analysis" portion of VCDAT is on hold for a while so we can get something out the door in a timely manner. I've dropped the dependency on the provenance code I had written up ages ago, and reverted to just using file URIs and variable IDs (which is pretty much how it worked before I got my mitts on it)