### PR TITLE
Add colormap functionality to vcs.js.

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,5 +1,24 @@
 var canvas;
 var renderer;
+var boxfill;
+var variables;
+
+
+function print_colormapnames()
+{
+  var namesPromise = vcs.colormapnames();
+  namesPromise.then((names) => {
+    console.log(names);
+  });
+}
+
+function print_getcolormap(name)
+{
+  var colorsPromise = vcs.getcolormap(name);
+  colorsPromise.then((colors) => {
+    console.log(colors);
+  });
+}
 
 function vcs_boxfill_close()
 {
@@ -10,6 +29,26 @@ function vcs_boxfill_clear()
 {
   canvas.clear();
 }
+
+
+function vcs_plot_magma()
+{
+  vcs.createcolormap("mycolormap").then(() => {
+    return vcs.getcolormap("magma");
+  }).then((colorValues) => {
+    return vcs.setcolormap("mycolormap", colorValues);
+  }).then(() => {
+    boxfill["colormap"] = "mycolormap";
+    var rendererPromise = canvas.plot(variables.clt, boxfill);
+    rendererPromise.then((r) => {
+      renderer = r;
+      renderer.onImageReady(() => {
+        console.log("Ready magma");
+      });
+    });
+  });
+}
+
 
 function vcs_boxfill_resize()
 {
@@ -93,7 +132,7 @@ $(function () {
   operations = [{"subRegion": {'longitude1': [70, 180], 'latitude1': [0, 90]}},
                 {"subSlice": {'longitude1': [null,null,2], 'latitude1': [null,null,2]}}];
   axis_order = [0, 1, 3, 2];
-  var variables = {
+  variables = {
     // unstructured grid
     "sample3": {"uri": "sampleGenGrid3.nc", "variable": "sample"},
     "sample3_subset": {"uri": "sampleGenGrid3.nc", "variable": "sample",
@@ -119,7 +158,7 @@ $(function () {
     "airt" : {"uri": "coads_climatology.nc", "variable": "AIRT"}
   }
 
-  var boxfill = {"fillareaopacity": [], "datawc_timeunits": "days since 2000", "projection": "linear", "xticlabels1": "*", "xticlabels2": "*", "ymtics1": "", "ymtics2": "", "datawc_x1": 1e+20, "datawc_x2": 1e+20, "boxfill_type": "linear", "xmtics1": "", "fillareacolors": null, "xmtics2": "", "color_2": 255, "datawc_calendar": 135441, "fillareaindices": [1], "color_1": 0, "colormap": null, "missing": [0.0, 0.0, 0.0, 100.0], "xaxisconvert": "linear", "level_2": 1e+20, "ext_1": false, "ext_2": false, "datawc_y2": 1e+20, "datawc_y1": 1e+20, "yaxisconvert": "linear", "legend": null, "name": "__boxfill_717978942019492", "yticlabels1": "*", "yticlabels2": "*", "fillareastyle": "solid", "levels": [1e+20, 1e+20], "g_name": "Gfb", "level_1": 1e+20};
+  boxfill = {"fillareaopacity": [], "datawc_timeunits": "days since 2000", "projection": "linear", "xticlabels1": "*", "xticlabels2": "*", "ymtics1": "", "ymtics2": "", "datawc_x1": 1e+20, "datawc_x2": 1e+20, "boxfill_type": "linear", "xmtics1": "", "fillareacolors": null, "xmtics2": "", "color_2": 255, "datawc_calendar": 135441, "fillareaindices": [1], "color_1": 0, "colormap": null, "missing": [0.0, 0.0, 0.0, 100.0], "xaxisconvert": "linear", "level_2": 1e+20, "ext_1": false, "ext_2": false, "datawc_y2": 1e+20, "datawc_y1": 1e+20, "yaxisconvert": "linear", "legend": null, "name": "__boxfill_717978942019492", "yticlabels1": "*", "yticlabels2": "*", "fillareastyle": "solid", "levels": [1e+20, 1e+20], "g_name": "Gfb", "level_1": 1e+20};
   var vector =         {"datawc_timeunits": "days since 2000", "projection": "linear", "reference": 1e+20, "xticlabels1": "*", "xticlabels2": "*", "linecolor": null, "ymtics1": "", "ymtics2": "", "linewidth": null, "datawc_x1": 1e+20, "datawc_x2": 1e+20, "xmtics1": "", "xmtics2": "", "datawc_calendar": 135441, "alignment": "center", "type": "arrows", "colormap": null, "xaxisconvert": "linear", "scale": 1.0, "linetype": null, "datawc_y2": 1e+20, "datawc_y1": 1e+20, "yaxisconvert": "linear", "name": "vector_full",   "yticlabels1": "*", "yticlabels2": "*", "scalerange": [0.1, 1.0], "scaleoptions": ["off", "constant", "normalize", "linear", "constantNNormalize", "constantNLinear"], "g_name": "Gv", "scaletype": "constantNNormalize"};
   var vector_subview = {"datawc_timeunits": "days since 2000", "projection": "linear", "reference": 1e+20, "xticlabels1": "*", "xticlabels2": "*", "linecolor": null, "ymtics1": "", "ymtics2": "", "linewidth": null, "datawc_x1": 60,    "datawc_x2": 180,   "xmtics1": "", "xmtics2": "", "datawc_calendar": 135441, "alignment": "center", "type": "arrows", "colormap": null, "xaxisconvert": "linear", "scale": 1.0, "linetype": null, "datawc_y2": 90,    "datawc_y1": 0,     "yaxisconvert": "linear", "name": "subset_vector", "yticlabels1": "*", "yticlabels2": "*", "scalerange": [0.1, 1.0], "scaleoptions": ["off", "constant", "normalize", "linear", "constantNNormalize", "constantNLinear"], "g_name": "Gv", "scaletype": "constantNNormalize"};
   var isofill = {"g_name": "Gfi"};

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,6 +13,7 @@
       <a onclick="vcs_boxfill_close()" href="javascript:void(0)">Close</a>
       <a onclick="vcs_boxfill_clear()" href="javascript:void(0)">Clear</a>
       <a onclick="vcs_boxfill_resize()" href="javascript:void(0)">Resize</a>
+      <a onclick="vcs_plot_magma()" href="javascript:void(0)">Magma</a>
       </td>
       <td><div class="plot" id="plotly-isofill"></div></td>
     </tr>
@@ -38,8 +39,10 @@
     <li><a onclick="print_variables('clt.nc')" href="javascript:void(0)">clt.nc variables example</a></li>
     <li><a onclick="print_variables('sampleCurveGrid4.nc')" href="javascript:void(0)">Curvilinear grid variable example</a></li>
     <li><a onclick="print_variables('sampleGenGrid3.nc')" href="javascript:void(0)">Generic grid variable example</a></li>
+    <li><a onclick="print_colormapnames()" href="javascript:void(0)">Color map names</a></li>
+    <li><a onclick="print_getcolormap('magma')" href="javascript:void(0)">Magma colors</a></li>
   </ul>
-  
+
   <script type="text/javascript" src="http://localhost:9000/vcs.js"></script>
   <script type="text/javascript" src="demo.js"></script>
 </body>

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,36 @@ function variables(fileName) {
     .then((client) => { return client.pvw.session.call('cdat.file.variables', [fileName]); });
 }
 
+function colormapnames() {
+  const connection = connect('server');
+  return connection.vtkweb
+    .then((client) => { return client.pvw.session.call('vcs.colormapnames'); });
+}
+
+function getcolormap(name) {
+  const connection = connect('server');
+  return connection.vtkweb
+    .then((client) => {
+      return client.pvw.session.call('vcs.getcolormap', [name]);
+    });
+}
+
+function setcolormap(name, values) {
+  const connection = connect('server');
+  return connection.vtkweb
+    .then((client) => {
+      return client.pvw.session.call('vcs.setcolormap', [name, values]);
+    });
+}
+
+function createcolormap(name, nameSource) {
+  const connection = connect('server');
+  return connection.vtkweb
+    .then((client) => {
+      return client.pvw.session.call('vcs.createcolormap', [name, nameSource]);
+    });
+}
+
 function init(el, renderingType) {
   const connection = connect(renderingType);
   let backend = null;
@@ -91,7 +121,7 @@ function init(el, renderingType) {
     },
 
     clear() {
-      this.backend.clear(this);
+      return this.backend.clear(this);
     },
 
     close() {
@@ -108,5 +138,9 @@ function init(el, renderingType) {
 export {
   init,
   variables,
+  colormapnames,
+  getcolormap,
+  setcolormap,
+  createcolormap,
   remoteRenderer,
 };

--- a/vcs_server/Visualizer.py
+++ b/vcs_server/Visualizer.py
@@ -88,3 +88,32 @@ class Visualizer(protocols.vtkWebProtocol):
             del canvas
             return True
         return False
+
+    # Colormap routines
+    @exportRpc('vcs.colormapnames')
+    def colormapnames(self):
+        """Returns a list of colormap names"""
+        return vcs.elements['colormap'].keys()
+
+    @exportRpc('vcs.getcolormap')
+    def getcolormap(self, name):
+        """Returns the color values in a colormap"""
+        name = str(name)
+        return vcs.getcolormap(name).getindex().values()
+
+    @exportRpc('vcs.setcolormap')
+    def setcolormap(self, name, values):
+        """Sets color values in a specified colormap"""
+        name = str(name)
+        cm = vcs.getcolormap(name)
+        for i, value in enumerate(values):
+            cm.setcolorcell(i, value[0], value[1], value[2], value[3])
+
+    @exportRpc('vcs.createcolormap')
+    def createcolormap(self, name, nameSource):
+        """Creates a colormap 'name' as a copy of 'nameSource'"""
+        name = str(name)
+        if (nameSource is None):
+            nameSource = 'default'
+        nameSource = str(nameSource)
+        cm = vcs.createcolormap(name, nameSource)


### PR DESCRIPTION
The functionality added is similar with what is available in vcs.
A user can:

Get all colormap names: colormapnames
Create a copy of an existing colormap with a new name: createcolormap
Get all color values: getcolormap
Set all color values: setcolormap

See demo.js vcs_plot_magma for an example of how to use these functions.