### PR TITLE
Fix for variables with a lon or lat (but not both).

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -142,7 +142,7 @@ function print_variables (filename) {
                     lonLat = '(' + vars[v].lonLat[0] + ', ' +
                         vars[v].lonLat[1] + ')';
                 }
-                logString = v + shape + '[' + vars[v].name + ', ' +
+                logString = v + shape + ' [' + vars[v].name + ', ' +
                     vars[v].units + boundsString + ']' + ': ' + axisList;
                 if (lonLat) {
                     logString += (', ' + lonLat);

--- a/demo/index.html
+++ b/demo/index.html
@@ -37,6 +37,8 @@
   <ul>
     <li><a onclick="print_variables('coads_climatology.nc')" href="javascript:void(0)">Rectilinear grid variables example</a></li>
     <li><a onclick="print_variables('clt.nc')" href="javascript:void(0)">clt.nc variables example</a></li>
+    <li><a onclick="print_variables('navy_land.nc')" href="javascript:void(0)">navy_land.nc variables example</a></li>
+    <li><a onclick="print_variables('ta_ncep_87-6-88-4.nc')" href="javascript:void(0)">ta_ncep_87-6-88-4.nc variables example</a></li>    
     <li><a onclick="print_variables('sampleCurveGrid4.nc')" href="javascript:void(0)">Curvilinear grid variable example</a></li>
     <li><a onclick="print_variables('sampleGenGrid3.nc')" href="javascript:void(0)">Generic grid variable example</a></li>
     <li><a onclick="printcolormapnames()" href="javascript:void(0)">Print colormaps</a></li>

--- a/vcs_server/FileLoader.py
+++ b/vcs_server/FileLoader.py
@@ -42,20 +42,23 @@ class FileLoader(protocols.vtkWebProtocol):
             for axis in var.getAxisList():
                 axisList.append(axis.id)
             lonLat = None
-            if (var.getLongitude() and
+            if (var.getLongitude() and var.getLatitude() and
                     not isinstance(var.getGrid(), cdms2.grid.AbstractRectGrid)):
+                # for curvilinear and generic grids
+                # 1. getAxisList() returns the axes and
+                # 2. getLongitude() and getLatitude() return the lon,lat variables
                 lonName = var.getLongitude().id
                 latName = var.getLatitude().id
                 lonLat = [lonName, latName]
                 # add min/max for longitude/latitude
                 if (lonName not in outVars):
                     outVars[lonName] = {}
-                lonData = var.getLongitude()[:].data
+                lonData = var.getLongitude()[:]
                 outVars[lonName]['bounds'] =\
                   [numpy.amin(lonData), numpy.amax(lonData)]
                 if (latName not in outVars):
                     outVars[latName] = {}
-                latData = var.getLatitude()[:].data
+                latData = var.getLatitude()[:]
                 outVars[latName]['bounds'] =\
                   [numpy.amin(latData), numpy.amax(latData)]
             if (isinstance(var.getGrid(), cdms2.grid.AbstractRectGrid)):


### PR DESCRIPTION
Variables in curvilinear or generic grids have
getLongitude(), getLatitude() and getAxisList().

Fix for https://github.com/UV-CDAT/vcs-js/issues/19