### PR TITLE
Try to get resize working better

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -96,8 +96,7 @@ function vcs_plot_mycolormap()
 
 function vcs_boxfill_resize()
 {
-  canvas.el.style.height = '400px';
-  renderer.resize();
+  canvas.resize(600, 400);
   console.log('div resize');
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,12 @@ function init(el, renderingType) {
       return this.backend.clear(this);
     },
 
+    resize(newWidth, newHeight) {
+      el.style.width = `${newWidth}px`;
+      el.style.height = `${newHeight}px`;
+      return this.backend.resize(this, newWidth, newHeight);
+    },
+
     close() {
       Object.keys(this.connection).map((k) => {
         return this.connection[k].then((c) => {

--- a/src/vtkweb/index.js
+++ b/src/vtkweb/index.js
@@ -124,6 +124,16 @@ const backend = {
       return client.pvw.session.call('vcs.canvas.clear', [canvas.windowId]);
     });
   },
+  resize(canvas, newWidth, newHeight) {
+    if (!canvas.windowId) {
+      return Promise.resolve(false);
+    }
+    return canvas.connection.vtkweb.then((client) => {
+      return client.pvw.session.call('vcs.canvas.resize', [canvas.windowId, newWidth, newHeight]).then(() => {
+        this._renderer[canvas.windowId].renderer.resize();
+      });
+    });
+  },
 };
 
 export { backend as default };


### PR DESCRIPTION
The resize code path did not connect to the backend at all.  This PR makes the connection that calls the `vcs.canvas.resize` rpc method, and only when that promise resolves does it trigger a resize on the client-side `RemoteRenderer` object.

Now the demo resize functionality seems to work fine in onscreen mode.  However in offscreen mode there is still something wrong: the text labels don't seem to change, even though the image and scalar bar are resized properly.

This does change the behavior of the api a little though.  Now instead of setting the size on the container and calling a resize method, you just call resize on the "canvas" with the new width and height.  If that's a problem, we can iterate on this code change.